### PR TITLE
Remove old stages from `dvc.lock`

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -1,61 +1,52 @@
+---
 schema: '2.0'
 stages:
-  1-stage:
-    cmd: Rscript stages/01-stage.R
-    deps:
-    - path: stages/01-stage.R
-      md5: c468dc14527e00c339f146e1dba2bd3b
-      size: 118
-    outs:
-    - path: data/mtcars.parquet
-      md5: 77cf29accf9535522fad7db1486eff9a
-      size: 6243
-  download:
-    cmd: stages/01_download.sh
-    deps:
-    - path: checksum
-      hash: md5
-      md5: eb95c933fce96888362b021791396620.dir
-      size: 53
-      nfiles: 1
-    - path: stages/01_download.sh
-      hash: md5
-      md5: ad6a31440b3b1ededc1b0d648792c8aa
-      size: 617
-    outs:
-    - path: download
-      hash: md5
-      md5: e8fce35978bb70199fd860ae25f84d13.dir
-      size: 134615801
-      nfiles: 4
-  invalidate:
-    cmd: stages/00_invalidate.sh
-    deps:
-    - path: stages/00_invalidate.sh
-      hash: md5
-      md5: 56e1c4848db41a680abcebb40fb17832
-      size: 461
-    outs:
-    - path: checksum
-      hash: md5
-      md5: eb95c933fce96888362b021791396620.dir
-      size: 53
-      nfiles: 1
   build:
     cmd: stages/02_build.sh
     deps:
-    - path: download
-      hash: md5
+    - hash: md5
       md5: e8fce35978bb70199fd860ae25f84d13.dir
-      size: 134615801
       nfiles: 4
-    - path: stages/02_build.sh
-      hash: md5
+      path: download
+      size: 134615801
+    - hash: md5
       md5: 985b31e7a47598f9c6553af0d6750344
+      path: stages/02_build.sh
       size: 506
     outs:
-    - path: brick
-      hash: md5
+    - hash: md5
       md5: e33d1d6c659bd9b51db31b893fa56855.dir
-      size: 272995465
       nfiles: 5
+      path: brick
+      size: 272995465
+  download:
+    cmd: stages/01_download.sh
+    deps:
+    - hash: md5
+      md5: eb95c933fce96888362b021791396620.dir
+      nfiles: 1
+      path: checksum
+      size: 53
+    - hash: md5
+      md5: ad6a31440b3b1ededc1b0d648792c8aa
+      path: stages/01_download.sh
+      size: 617
+    outs:
+    - hash: md5
+      md5: e8fce35978bb70199fd860ae25f84d13.dir
+      nfiles: 4
+      path: download
+      size: 134615801
+  invalidate:
+    cmd: stages/00_invalidate.sh
+    deps:
+    - hash: md5
+      md5: 56e1c4848db41a680abcebb40fb17832
+      path: stages/00_invalidate.sh
+      size: 461
+    outs:
+    - hash: md5
+      md5: eb95c933fce96888362b021791396620.dir
+      nfiles: 1
+      path: checksum
+      size: 53


### PR DESCRIPTION
Many bricks have old stages from the brick-template.
